### PR TITLE
White pixels

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,7 +33,7 @@ impl Decoder for DecoderGrayscale {
         for level in 0..levels {
             let mut index = 0;
 
-            traverse_level(level, levels, width, height, |column, line| {
+            let process_pixel = #[inline(always)] |column, line| {
                 let diff = grid[level + 1][index];
                 let prediction = interpolate(
                     levels,
@@ -45,7 +45,9 @@ impl Decoder for DecoderGrayscale {
                 let pixel = gray(prediction.wrapping_add(diff));
                 img.put_pixel(column, line, pixel);
                 index += 1;
-            });
+            };
+
+            traverse_level(level, levels, width, height, process_pixel);
         }
 
         return img;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -41,7 +41,13 @@ impl Encoder for EncoderGrayscale {
 
                 let actual_value = input.get_pixel(column, line).data[0];
                 let diff = actual_value.wrapping_sub(prediction);
-                let quanted_diff = quantizator.quantize(diff);
+                let mut quanted_diff = quantizator.quantize(diff);
+
+                let overflow = prediction.checked_add(quanted_diff).is_none();
+                let overflow_is_expected = prediction.checked_add(diff).is_none();
+                if  overflow != overflow_is_expected {
+                    quanted_diff = diff;
+                }
 
                 grid[level + 1].push(quanted_diff);
                 let pixel = gray(prediction.wrapping_add(quanted_diff));

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -31,7 +31,7 @@ impl Encoder for EncoderGrayscale {
         }
 
         for level in 0..levels {
-            traverse_level(level, levels, width, height, |column, line| {
+            let process_pixel = #[inline(always)] |column, line| {
                 let prediction = interpolate(
                     levels,
                     level + 1,
@@ -52,7 +52,9 @@ impl Encoder for EncoderGrayscale {
                 grid[level + 1].push(quanted_diff);
                 let pixel = gray(prediction.wrapping_add(quanted_diff));
                 input.put_pixel(column, line, pixel);
-            });
+            };
+
+            traverse_level(level, levels, width, height, process_pixel);
         }
         return grid;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(stmt_expr_attributes)]
+
 extern crate bincode;
 extern crate byteorder;
 extern crate flate2;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(stmt_expr_attributes)]
+
 extern crate bincode;
 extern crate byteorder;
 extern crate flate2;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,8 +102,10 @@ where
 
     let mut line = 0;
     while line < height {
-        for column in (start..width).step_by(step) {
+        let mut column = start;
+        while column < width {
             f(column as u32, line as u32);
+            column += step;
         }
 
         line += substep;
@@ -111,8 +113,10 @@ where
             break;
         }
 
-        for column in (0..width).step_by(substep as usize) {
+        let mut column = 0;
+        while column < width {
             f(column as u32, line as u32);
+            column += substep;
         }
         line += substep;
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,7 +18,7 @@ pub enum QuantizationLevel {
 }
 
 pub struct Quantizator {
-    error: usize
+    table: [u8; 256]
 }
 
 impl Quantizator {
@@ -30,15 +30,23 @@ impl Quantizator {
             QuantizationLevel::High => 30,
         };
 
-        Quantizator { error }        
+        let scale = 2 * error + 1;
+        let quantize = |x| {
+            let r = (x as usize + error) / scale;
+            let v = r * scale;
+            v as u8
+        };
+
+        let mut table = [0; 256];
+        for x in 0..table.len() {
+            table[x] = quantize(x as u8);
+        }
+        Quantizator { table }        
     }
     
     #[inline]
     pub fn quantize(&self, value: u8) -> u8 {
-        let scale = 2 * self.error + 1;
-        let r = (value as usize + self.error) / scale;
-        let v = r * scale;
-        v as u8
+        self.table[value as usize]
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,14 +77,14 @@ pub struct CrossedValues {
 impl CrossedValues {
     #[inline]
     pub fn prediction(&self) -> u8 {
-        let average = |x, y| (x as usize + y as usize + 1) / 2;
+        let average = |x, y| (x as usize + y as usize + 1) >> 1; // div 2
 
         let left  = average(self.left_top,  self.left_bot);
         let right = average(self.right_bot, self.right_top);
         let top   = average(self.right_top, self.left_top);
         let bot   = average(self.right_bot, self.left_bot);
 
-        let average = (left + right + top + bot + 1) / 4;
+        let average = (left + right + top + bot + 1) >> 2; // div 4
 
         average as u8
     }


### PR DESCRIPTION
- Added lookup table for quantizator (+30% performance improvement)
- Added workaround for "white pixels" problem
- Added #[inline(always)] for lambda provided to traverse_levels (+80-90% performance improvement)